### PR TITLE
Integrate RELIC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,12 @@ __pycache__
 *.c
 
 # Other generated files
+*/version_relic.py
 */version.py
 */cython_version.py
 htmlcov
 .coverage
+RELIC-INFO
 MANIFEST
 
 # Sphinx

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "astropy-helpers"]
 	path = astropy_helpers
 	url = https://github.com/astropy/astropy-helpers.git
+[submodule "relic"]
+	path = relic
+	url = https://github.com/jhunkeler/relic.git

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.rst
 
+include RELIC-INFO
 include ez_setup.py
 include ah_bootstrap.py
 include setup.cfg
@@ -12,7 +13,9 @@ recursive-include scripts *
 prune docs/_build
 prune build
 
+recursive-include relic *
 recursive-include astropy_helpers *
+exclude relic/.git
 exclude astropy_helpers/.git
 exclude astropy_helpers/.gitignore
 

--- a/gwcs/__init__.py
+++ b/gwcs/__init__.py
@@ -11,6 +11,8 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 # should keep this content at the top.
 # ----------------------------------------------------------------------------
 from ._astropy_init import *
+from .version_relic import *
+__githash__ = __version_commit__
 # ----------------------------------------------------------------------------
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,14 @@ import sys
 import ah_bootstrap
 from setuptools import setup
 
+sys.path.insert(1, 'relic')
+import relic.release
+
+# Automatically drop 'v' prefix on version data
+version = relic.release.get_info(remove_pattern='v')
+# Write version data to gwcs/version_relic.py; gwcs/version.py already exists
+relic.release.write_template(version, 'gwcs', filename='version_relic.py')
+
 #A dirty hack to get around some early import/configurations ambiguities
 if sys.version_info[0] >= 3:
     import builtins
@@ -17,7 +25,6 @@ builtins._ASTROPY_SETUP_ = True
 
 from astropy_helpers.setup_helpers import (
     register_commands, adjust_compiler, get_debug_option, get_package_info)
-from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
 # Get some values from the setup.cfg
@@ -43,13 +50,10 @@ LONG_DESCRIPTION = package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '0.6.dev'
+VERSION = version.pep386
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION
-
-if not RELEASE:
-    VERSION += get_git_devstr(False)
 
 # Populate the dict of setup command overrides; this should be done before
 # invoking any other functionality from distutils since it can potentially


### PR DESCRIPTION
This uses the submodule method. `astropy_helpers` could be modified to update/init ALL submodules to avoid the need for `git clone --recursive`. As it stands, it only cares about itself.
